### PR TITLE
More SFZ parser fixes

### DIFF
--- a/soundfonts/src/sfz/lexer.rs
+++ b/soundfonts/src/sfz/lexer.rs
@@ -255,7 +255,7 @@ fn parse_region_flags(parser: &mut StringParser) -> Option<SfzRegionFlags> {
 
     try_parse!(parser, SfzRegionFlags::DefaultPath, String, parser, {
         parse_basic_tag_name(parser, "default_path")?;
-        Some(parser.parse_until_space())
+        Some(parser.parse_until_space().replace('\\', "/"))
     });
 
     try_parse!(

--- a/soundfonts/src/sfz/mod.rs
+++ b/soundfonts/src/sfz/mod.rs
@@ -110,7 +110,10 @@ impl RegionParamsBuilder {
             self.sample?.into()
         };
 
-        let sample_path = base_path.join(relative_sample_path);
+        let sample_path = match base_path.join(&relative_sample_path).canonicalize() {
+            Ok(path) => path,
+            Err(_) => base_path.join(relative_sample_path),
+        };
 
         let keyrange: RangeInclusive<u8>;
 

--- a/soundfonts/src/sfz/mod.rs
+++ b/soundfonts/src/sfz/mod.rs
@@ -110,10 +110,11 @@ impl RegionParamsBuilder {
             self.sample?.into()
         };
 
-        let sample_path = match base_path.join(&relative_sample_path).canonicalize() {
-            Ok(path) => path,
-            Err(_) => base_path.join(relative_sample_path),
-        };
+        let mut sample_path = base_path.join(&relative_sample_path);
+        match sample_path.canonicalize() {
+            Ok(path) => sample_path = path,
+            Err(_) => return None,
+        }
 
         let keyrange: RangeInclusive<u8>;
 

--- a/soundfonts/src/sfz/mod.rs
+++ b/soundfonts/src/sfz/mod.rs
@@ -110,7 +110,7 @@ impl RegionParamsBuilder {
             self.sample?.into()
         };
 
-        let mut sample_path = base_path.join(&relative_sample_path);
+        let mut sample_path = base_path.join(relative_sample_path);
         match sample_path.canonicalize() {
             Ok(path) => sample_path = path,
             Err(_) => return None,


### PR DESCRIPTION
- Fix `default_path` parsing
- Ignore regions with samples that don't exist