### PR TITLE
Change library name from core to xsynth_core

### DIFF
--- a/kdmapi/Cargo.toml
+++ b/kdmapi/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-core = { path = "../core", package = "xsynth-core" }
+xsynth-core = { path = "../core" }
 realtime = { path = "../realtime", package = "xsynth-realtime" }
 winapi = { version = "0.3.9", features = ["synchapi", "winuser"] }
 cfg-if = "1.0.0"

--- a/kdmapi/src/lib.rs
+++ b/kdmapi/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use core::{
+use xsynth_core::{
     channel::ChannelConfigEvent,
     soundfont::{SampleSoundfont, SoundfontBase},
 };

--- a/realtime/Cargo.toml
+++ b/realtime/Cargo.toml
@@ -15,7 +15,7 @@ rayon = "1.5.3"
 spin_sleep = "1.0.0"
 to_vec = "0.1.0"
 wav = "1.0.0"
-core = { path = "../core", package = "xsynth-core" }
+xsynth-core = { path = "../core" }
 
 [dev-dependencies]
 midi-toolkit-rs = { git = "https://github.com/arduano/midi-toolkit-rs", rev = "907dec1" }

--- a/realtime/src/config.rs
+++ b/realtime/src/config.rs
@@ -1,4 +1,4 @@
-use core::channel::ChannelInitOptions;
+use xsynth_core::channel::ChannelInitOptions;
 use std::ops::RangeInclusive;
 
 pub struct XSynthRealtimeConfig {

--- a/realtime/src/event_senders.rs
+++ b/realtime/src/event_senders.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crossbeam_channel::Sender;
 
-use core::channel::{ChannelAudioEvent, ChannelConfigEvent, ChannelEvent, ControlEvent};
+use xsynth_core::channel::{ChannelAudioEvent, ChannelConfigEvent, ChannelEvent, ControlEvent};
 
 use crate::{util::ReadWriteAtomicU64, SynthEvent};
 

--- a/realtime/src/lib.rs
+++ b/realtime/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod config;
 mod util;
 
-pub use core::channel_group::SynthEvent;
+pub use xsynth_core::channel_group::SynthEvent;
 
 mod realtime_synth;
 pub use realtime_synth::*;

--- a/realtime/src/realtime_synth.rs
+++ b/realtime/src/realtime_synth.rs
@@ -13,7 +13,7 @@ use cpal::{
 };
 use crossbeam_channel::{bounded, unbounded};
 
-use core::{
+use xsynth_core::{
     channel::VoiceChannel,
     effects::VolumeLimiter,
     helpers::{prepapre_cache_vec, sum_simd},

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-core = { path = "../core", package = "xsynth-core" }
+xsynth-core = { path = "../core" }
 crossbeam-channel = "0.5.1"
 hound = "3.5.0"
 rayon = "1.5.3"

--- a/render/src/builder.rs
+++ b/render/src/builder.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use std::sync::Arc;
 
-use core::{
+use xsynth_core::{
     channel::{ChannelAudioEvent, ChannelConfigEvent, ControlEvent},
     channel_group::SynthEvent,
     soundfont::{LoadSfzError, SampleSoundfont, SoundfontBase},

--- a/render/src/config.rs
+++ b/render/src/config.rs
@@ -1,4 +1,4 @@
-use core::{channel::ChannelInitOptions, soundfont::SoundfontInitOptions};
+use xsynth_core::{channel::ChannelInitOptions, soundfont::SoundfontInitOptions};
 
 #[derive(PartialEq, Clone, Copy)]
 pub enum XSynthRenderAudioFormat {

--- a/render/src/rendered.rs
+++ b/render/src/rendered.rs
@@ -1,4 +1,4 @@
-use core::{
+use xsynth_core::{
     channel_group::{ChannelGroup, ChannelGroupConfig, SynthEvent},
     effects::VolumeLimiter,
     AudioPipe, AudioStreamParams,


### PR DESCRIPTION
Using `xsynth_core` as `core` conflicts with rust's `core` library when compiling with `-Zbuild-std`